### PR TITLE
Show more detail for test times

### DIFF
--- a/junit_parser.js
+++ b/junit_parser.js
@@ -70,7 +70,7 @@ $.getJSON("junit.json", function(junitData) {
                 )
                 .append(
                     Span()
-                    .html('Time: ' + parseInt(testCase.time).toFixed(2))
+                    .html('Time: ' + parseFloat(testCase.time).toFixed(2))
                     .addClass('test__time')
                 )
                 .addClass('test')

--- a/template.html
+++ b/template.html
@@ -199,7 +199,7 @@
                 )
                 .append(
                     Span()
-                    .html('Time: ' + parseInt(testCase.time).toFixed(2))
+                    .html('Time: ' + parseFloat(testCase.time).toFixed(2))
                     .addClass('test__time')
                 )
                 .addClass('test')


### PR DESCRIPTION
Some tests can run very quickly, so switching to a `parseFloat` here gives users a bit more detail on the tests.  