### PR TITLE
Take care of line breaks in failure messages

### DIFF
--- a/junit_parser.js
+++ b/junit_parser.js
@@ -85,7 +85,7 @@ $.getJSON("junit.json", function(junitData) {
                     Br()
                 ).append(
                     Span()
-                    .html(testCase.failureMessage)
+                    .html(testCase.failureMessage.replace(/(?:\r\n|\r|\n)/g, '<br />'))
                     .addClass('test__fail')
                 )
                 .addClass('test--fail')

--- a/template.html
+++ b/template.html
@@ -214,7 +214,7 @@
                     Br()
                 ).append(
                     Span()
-                    .html(testCase.failureMessage)
+                    .html(testCase.failureMessage.replace(/(?:\r\n|\r|\n)/g, '<br />'))
                     .addClass('test__fail')
                 )
                 .addClass('test--fail')


### PR DESCRIPTION
In my case the failure message contains text with linebreaks (\n).
For a correct representation these linebreaks have to be transfered to html linebreaks.