### PR TITLE
Added posibility to use date token in saved HTML file name

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,18 @@ You can do both
 junit-viewer --results=folder_or_file_path --save=destination_file.html --port=9090
 ```
 
+Tokens in destination filename
+------------------------------
+
+The command below will create `destination_file_2015-11-18.html` file.
+
+```
+junit-viewer --results=folder_or_file_path --save=destination_file_$[date].html
+```
+
+The string, `date` can be replaced with valid date-format strings.
+It uses [date-format](https://www.npmjs.com/package/date-format) plugin.
+
 Test It
 =======
 

--- a/README.md
+++ b/README.md
@@ -32,9 +32,7 @@ You can do both
 junit-viewer --results=folder_or_file_path --save=destination_file.html --port=9090
 ```
 
-Tokens in destination filename
-------------------------------
-
+You can use token to show the current date/time in the destination file.
 The command below will create `destination_file_2015-11-18.html` file.
 
 ```

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 var path = require('path'),
     fs = require('fs'),
-    parser = new require('xml2js').Parser();
+    parser = new require('xml2js').Parser(),
+    dateFormat = require('date-format');
 
 
 var commandArgs = {};
@@ -151,6 +152,12 @@ function startServer() {
     console.log('Running and viewer at http://localhost:' + commandArgs.port);
 }
 
+function replaceTokens(string) {
+    return string.replace(/\$[\(\{\[](date|[ymhdso-]+)[\)\}\]]/i, function (match, format) {
+        return dateFormat(format.toLowerCase() == "date" ? "yyyy-MM-dd" : format, new Date());
+    });
+}
+
 function save() {
     var thing = fs.readFileSync(__dirname + '/template.html')
         .toString()
@@ -158,7 +165,7 @@ function save() {
             results: jsonResults(),
             title: getTitle()
         }));
-    fs.writeFile(commandArgs.save, thing, function(err) {
+    fs.writeFile(replaceTokens(commandArgs.save), thing, function(err) {
         if (err) {
             return console.log(err);
         }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "license": "ISC",
   "repository": "https://github.com/lukejpreston/junit_viewer.git",
   "dependencies": {
+    "date-format": "0.0.2",
     "express": "^4.12.4",
     "xml2js": "^0.4.8"
   }


### PR DESCRIPTION
I have created this modification to support saving converted HTML file with the current date.
I.e:

```
$> junit-viewer --results=test-results --save=test_results_$[date].html
```

will create `test_results_2015-11-09.html` file. The string, `date` can be replaced with valid date-format strings. It uses [date-format](https://www.npmjs.com/package/date-format) plugin.
